### PR TITLE
Apply a Security Descriptor to the Driver's Device Object

### DIFF
--- a/edrav2/iprj/edrdrv/src/ioctl.cpp
+++ b/edrav2/iprj/edrdrv/src/ioctl.cpp
@@ -326,14 +326,16 @@ NTSTATUS initialize()
 	bool fSuccessInit = false;
 	__try
 	{
-		// Create devise
-		IFERR_RET(IoCreateDevice(
-			g_pCommonData->pDriverObject,      // Our Driver Object
+		// Create device
+		IFERR_RET(IoCreateDeviceSecure(
+			g_pCommonData->pDriverObject,   // Our Driver Object
 			0,                              // We don't use a device extension
 			&c_usNtDeviceName,              // Device name
 			FILE_DEVICE_UNKNOWN,            // Device type
 			FILE_DEVICE_SECURE_OPEN,        // Device characteristics
 			FALSE,                          // Not an exclusive device
+			&SDDL_DEVOBJ_SYS_ALL_ADM_ALL,	// Restrict access to the device object to only LocalSystem and Administrators
+			NULL,							// No device class GUID
 			&g_pCommonData->pIoctlDeviceObject)); // Returned ptr to Device Object
 
 		// Create symlink

--- a/edrav2/iprj/edrdrv/src/kernelcmnlib/kernelstl.hpp
+++ b/edrav2/iprj/edrdrv/src/kernelcmnlib/kernelstl.hpp
@@ -13,6 +13,7 @@
 #pragma warning(push, 3)
 #include <limits.h>
 #include <wdm.h>
+#include <wdmsec.h>
 #pragma warning(pop)
 
 #include "kernelstl/std.hpp"


### PR DESCRIPTION
Hey there,

Congrats on the release! This is a really exciting project. 

During a quick review, I found that you all are using `IoCreateDevice()` to create the driver's device object in `ioctl.cpp`. This function does not allow access to the device object to be restricted, so it defaults to being accessible by all users. With access to the device object through the associated symlink, any* user could start sending IOCTLs to the driver.

More information: [CWE-782](https://cwe.mitre.org/data/definitions/782.html)

The protection you all have in place to check whether the process sending the IRP is in the list of those authorized to communicate with the driver mitigates a good amount of the risk as even Local Administrators can't directly talk to the driver if their process isn't explicitly allowed. 

Subverting this check would involve injecting code into one of the "allowed" processes, which typically would require administrator rights. However, if there were an external misconfiguration, such as if low-privileged users are granted SeDebugPrivilege/SeTakeOwnershipPrivilege (which would never happen in an enterprise, right? 😉), they would gain the ability to inject into the process(es) and interact with the driver. Its not immediately clear how this list is initially populated, but it looks like access is controlled via PID, which has been [proven to be able to be bypassed](https://googleprojectzero.blogspot.com/2019/09/windows-exploitation-tricks-spoofing.html) as well. This may be a separate thing to look at though. 

Additionally, `isCurProcessTrusted()` is not implemented in `CMD_ERDDRV_IOCTL_STOP`, which wold allow any user to stop monitoring on the host regardless of what process they are in. 

This PR migrates to using `IoCreateDeviceSecure()` and a security descriptor which only allows LocalSystem and Administrators access to the device object.

**Note:** I was unable to fully validate this due to some issues compiling with the Netfilter and MadCodeHook dependencies, but this is a relatively simple change.